### PR TITLE
fix(vite.config): mdi icon convert camelCase to kebab-case

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,10 +14,10 @@ const mdi: Record<string, string> = {}
 Object.keys(mdicons).forEach((key) => {
   const value = (mdicons as Record<string, string>)[key]
   mdi[
-    key.replace(
-      /[A-Z]+(?![a-z])|[A-Z0-9]/g,
-      ($, ofs) => (ofs ? '-' : '') + $.toLowerCase(),
-    )
+    key
+      .replace(/([A-Z])/g, '-$1')
+      .toLowerCase()
+      .replace(/([0-9]+)/g, '-$1')
   ] = value
 })
 


### PR DESCRIPTION
When the previous solution encounters **mdiBattery80**, it will be converted to **mdi-battery-8-0**.
When using mdi-battery-80, an error that the icon cannot be found will be prompted.

This solution first converts uppercase letters and then matches one or more numbers.

There are some weird names here, such as mdiBattery10Bluetooth.  : )